### PR TITLE
Add maxResults option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,12 +31,12 @@ lister
 
 In addition to the standard stream options, you can also pass in specific options:
 
-* start     - string to start with
-* prefix    - the prefix to list under
-* start     - s3 will return every key alphabetically after this string
-* delimiter - the character you use to group keys
-* maxKeys   - maximum amount of keys in a batch, (limited to 1000)
-
+* start      - string to start with
+* prefix     - the prefix to list under
+* start      - s3 will return every key alphabetically after this string
+* delimiter  - the character you use to group keys
+* maxResults - maximum amount of keys to list in total
+* maxKeys    - maximum amount of keys in a batch, (limited to 1000)
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ module.exports = S3Lister;
  * @param {Object} s3  a knox-like client
  * @param {Object} options
  *   @field {Boolean} start  key to start with
+ *   @field {Boolean} maxResults  maximum amount of objects to list
  */
 function S3Lister (s3, options) {
   options || (options = {});
@@ -22,6 +23,8 @@ function S3Lister (s3, options) {
   this.marker     = options.start;
   this.options    = options;
   this.connecting = false;
+  this.resultCount = 0;
+  this.maxResults = options.maxResults;
 }
 util.inherits(S3Lister, stream.Readable);
 
@@ -65,7 +68,14 @@ S3Lister.prototype._list = function (options) {
     if (data.IsTruncated) self.marker = files[files.length - 1].Key;
     else self.ended = true;
 
-    files.forEach(function (file) { self.push(file); });
+    files.forEach(function (file) {
+      self.resultCount++;
+      if (self.maxResults && self.resultCount > self.maxResults) {
+        self.ended = true;
+        return;
+      }
+      self.push(file);
+    });
     if (self.ended) self.push(null);
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,19 @@ describe('S3Lister', function () {
       });
   });
 
+  it ('should list n files when options.maxResults is set to n', function (done) {
+    var maxResults = 5
+      , stream    = new S3Lister(client, { maxResults : maxResults })
+      , filesSeen = 0;
+
+    stream
+      .on('data',  function (file) { filesSeen += 1; })
+      .on('error', function (err)  { done(err); })
+      .on('end',   function ()     {
+        assert.equal(maxResults, filesSeen);
+        done();
+      });
+  });
 
   it('should list all the files if maxKeys < number of files', function (done) {
     var stream = new S3Lister(client, {


### PR DESCRIPTION
I added the possibility to limit the amount of total results:

```javascript
new S3Lister(client, {maxResults: 2000});
```

(Also added a test for this functionality and updated the README)